### PR TITLE
Allow skipping property freeing if test registers a shutdown function

### DIFF
--- a/tests/TestListenerTest.php
+++ b/tests/TestListenerTest.php
@@ -7,10 +7,15 @@ class TestListenerTest extends \PHPUnit_Framework_TestCase
     private $listener;
     private $dummyTest;
 
+    private $listenerFiltersShutdownFunction;
+    private $dummyTestRegistersShutdownFunction;
+
     protected function setUp()
     {
         $this->listener = new TestListener();
         $this->dummyTest = new DummyTest();
+        $this->listenerFiltersShutdownFunction = new TestListener(true);
+        $this->dummyTestRegistersShutdownFunction = new DummyTestRegistersShutdownFunction();
     }
 
     /**
@@ -33,6 +38,19 @@ class TestListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($this->dummyTest->phpUnitProperty);
     }
 
+    /**
+     * @test
+     */
+    public function shouldNotFreePhpUnitPropertyIfRegistersShutdownFunction()
+    {
+        $this->listenerFiltersShutdownFunction->endTest(
+            $this->dummyTestRegistersShutdownFunction,
+            0
+        );
+
+        $this->assertNotNull($this->dummyTestRegistersShutdownFunction->property);
+    }
+
     private function endTest()
     {
         $this->listener->endTest($this->dummyTest, 0);
@@ -47,4 +65,14 @@ class PHPUnit_Fake extends \PHPUnit_Framework_TestCase
 class DummyTest extends \PHPUnit_Fake
 {
     public $property = 1;
+}
+
+class DummyTestRegistersShutdownFunction extends \PHPUnit_Fake
+{
+    public $property = 1;
+
+    function foo()
+    {
+        register_shutdown_function(function() {return;});
+    }
 }


### PR DESCRIPTION
Should a test use register_shutdown_function(), freeing properties is likely to make this trigger a fatal error if a property is used by the function. This just adds an optional constructor flag to disable property freeing for those test files referencing register_shutdown_function().
See Issue https://github.com/mybuilder/phpunit-accelerator/issues/4