### PR TITLE
Ignore policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,57 @@
-PHPUnit Accelerator
-===================
+# PHPUnit Accelerator
+
 [![Build Status](https://secure.travis-ci.org/mybuilder/phpunit-accelerator.svg?branch=master)](http://travis-ci.org/mybuilder/phpunit-accelerator)
 
 Inspired by [Kris Wallsmith faster PHPUnit article](http://kriswallsmith.net/post/18029585104/faster-phpunit), we've created a [PHPUnit](http://phpunit.de) test listener that speeds up PHPUnit tests about 20% by freeing memory.
 
-Setup and Configuration
------------------------
-Add the following to your `composer.json` file
-```json
-{
-    "require-dev": {
-        "mybuilder/phpunit-accelerator": "~1.0"
-    }
-}
+## Installation
+
+To install this library, run the command below and you will get the latest version
+
+``` bash
+composer require mybuilder/phpunit-accelerator
 ```
 
-Update the vendor libraries
+## Usage
 
-    curl -s http://getcomposer.org/installer | php
-    php composer.phar install
-
-Usage
------
 Just add to your `phpunit.xml` configuration
+
 ```xml
 <phpunit>
     <listeners>
         <listener class="\MyBuilder\PhpunitAccelerator\TestListener"/>
+    </listeners>
+</phpunit>
+```
+
+### Ignoring Tests
+
+Sometimes it is necessary to ignore specific tests, where freeing their properties is undesired. For this use case, you have the ability to *extend the behaviour* of the listener by implementing the `IgnoreTestPolicy` interface.
+
+As an example, if we hypothetically wanted to ignore all tests which include "Legacy" in their test filename, we could create a custom ignore policy as follows
+
+```php
+<?php
+
+use MyBuilder\PhpunitAccelerator\IgnoreTestPolicy;
+
+class IgnoreLegacyTestPolicy implements IgnoreTestPolicy {
+    public function shouldIgnore(\ReflectionObject $testReflection) {
+        return strpos($testReflection->getFilename(), 'Legacy') !== false;
+    }
+}
+```
+
+And pass it to the constructor of our test listener in `phpunit.xml` configuration
+
+```xml
+<phpunit>
+    <listeners>
+        <listener class="\MyBuilder\PhpunitAccelerator\TestListener">
+            <arguments>
+                <object class="\IgnoreLegacyTestPolicy"/>
+            </arguments>
+        </listener>
     </listeners>
 </phpunit>
 ```

--- a/src/IgnoreTestPolicy.php
+++ b/src/IgnoreTestPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MyBuilder\PhpunitAccelerator;
+
+interface IgnoreTestPolicy
+{
+    /**
+     * @return boolean
+     */
+    public function shouldIgnore(\ReflectionObject $testReflection);
+}

--- a/src/TestListener.php
+++ b/src/TestListener.php
@@ -4,27 +4,33 @@ namespace MyBuilder\PhpunitAccelerator;
 
 class TestListener implements \PHPUnit_Framework_TestListener
 {
+    private $ignorePolicy;
+
     const PHPUNIT_PROPERTY_PREFIX = 'PHPUnit_';
+
+    public function __construct(IgnoreTestPolicy $ignorePolicy = null)
+    {
+        $this->ignorePolicy = ($ignorePolicy) ?: new NeverIgnoreTestPolicy();
+    }
 
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
-        $this->safelyFreeProperties($test);
+        $testReflection = new \ReflectionObject($test);
+
+        if ($this->ignorePolicy->shouldIgnore($testReflection)) {
+            return;
+        }
+
+        $this->safelyFreeProperties($test, $testReflection->getProperties());
     }
 
-    private function safelyFreeProperties(\PHPUnit_Framework_Test $test)
+    private function safelyFreeProperties(\PHPUnit_Framework_Test $test, array $properties)
     {
-        foreach ($this->getProperties($test) as $property) {
+        foreach ($properties as $property) {
             if ($this->isSafeToFreeProperty($property)) {
                 $this->freeProperty($test, $property);
             }
         }
-    }
-
-    private function getProperties(\PHPUnit_Framework_Test $test)
-    {
-        $reflection = new \ReflectionObject($test);
-
-        return $reflection->getProperties();
     }
 
     private function isSafeToFreeProperty(\ReflectionProperty $property)
@@ -58,4 +64,12 @@ class TestListener implements \PHPUnit_Framework_TestListener
     public function startTest(\PHPUnit_Framework_Test $test) {}
 
     public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
+}
+
+class NeverIgnoreTestPolicy implements IgnoreTestPolicy
+{
+    public function shouldIgnore(\ReflectionObject $testReflection)
+    {
+        return false;
+    }
 }

--- a/src/TestListener.php
+++ b/src/TestListener.php
@@ -11,7 +11,7 @@ class TestListener implements \PHPUnit_Framework_TestListener
         $this->safelyFreeProperties($test);
     }
 
-    private function safelyFreeProperties($test)
+    private function safelyFreeProperties(\PHPUnit_Framework_Test $test)
     {
         foreach ($this->getProperties($test) as $property) {
             if ($this->isSafeToFreeProperty($property)) {
@@ -20,24 +20,24 @@ class TestListener implements \PHPUnit_Framework_TestListener
         }
     }
 
-    private function getProperties($test)
+    private function getProperties(\PHPUnit_Framework_Test $test)
     {
         $reflection = new \ReflectionObject($test);
 
         return $reflection->getProperties();
     }
 
-    private function isSafeToFreeProperty($property)
+    private function isSafeToFreeProperty(\ReflectionProperty $property)
     {
         return !$property->isStatic() && $this->isNotPhpUnitProperty($property);
     }
 
-    private function isNotPhpUnitProperty($property)
+    private function isNotPhpUnitProperty(\ReflectionProperty $property)
     {
         return 0 !== strpos($property->getDeclaringClass()->getName(), self::PHPUNIT_PROPERTY_PREFIX);
     }
 
-    private function freeProperty($test, $property)
+    private function freeProperty(\PHPUnit_Framework_Test $test, \ReflectionProperty $property)
     {
         $property->setAccessible(true);
         $property->setValue($test, null);


### PR DESCRIPTION
This will allow you to now extend the Test Listener, providing the ability to ignore test cases where freeing properties is undesired. This changeset allows you to fix discussed points #4 and #5.