### PR TITLE
Add phpunit >=5.7 <7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ matrix:
       - php: nightly
         env: PHPUNIT=~6
       - php: hhvm
+        dist: trusty
         env: PHPUNIT=~5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,22 @@ script:
 
 matrix:
   include:
-    php:
-      - 5.6
-      env:
-        - PHPUNIT=~5.7
-      - 7.0
-      env:
-        - PHPUNIT=~5.7
-        - PHPUNIT=~6
-      - 7.1
-      env:
-        - PHPUNIT=~5.7
-        - PHPUNIT=~6
-      - nightly
-      env:
-        - PHPUNIT=~5.7
-        - PHPUNIT=~6
-      - hhvm
-      env:
-        - PHPUNIT=~5.7
-        - PHPUNIT=~6
+      - php: 5.6
+        env:
+          - PHPUNIT=~5.7
+      - php: 7.0
+        env:
+          - PHPUNIT=~5.7
+          - PHPUNIT=~6
+      - php: 7.1
+        env:
+          - PHPUNIT=~5.7
+          - PHPUNIT=~6
+      - php: nightly
+        env:
+          - PHPUNIT=~5.7
+          - PHPUNIT=~6
+      - php: hhvm
+        env:
+          - PHPUNIT=~5.7
+          - PHPUNIT=~6

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,10 @@ php:
   - hhvm
 
 env:
-  - PHPUNIT=4.7.*
-  - PHPUNIT=4.8.*
-  - PHPUNIT=5.0.*
-  - PHPUNIT=5.1.*
-  - PHPUNIT=5.2.*
-  - PHPUNIT=5.3.*
-  - PHPUNIT=5.4.*
-  - PHPUNIT=5.5.*
-  - PHPUNIT=5.6.*
   - PHPUNIT=5.7.*
+  - PHPUNIT=6.0.*
+  - PHPUNIT=6.1.*
+  - PHPUNIT=6.2.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,6 @@ language: php
 
 sudo: false
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - nightly
-  - hhvm
-
-env:
-  - PHPUNIT=5.7.*
-  - PHPUNIT=6.0.*
-  - PHPUNIT=6.1.*
-  - PHPUNIT=6.2.*
-
 cache:
   directories:
     - $HOME/.composer
@@ -26,3 +13,26 @@ before_script:
 
 script:
   - ./bin/phpunit
+
+matrix:
+  include:
+    php:
+      - 5.6
+      env:
+        - PHPUNIT=~5.7
+      - 7.0
+      env:
+        - PHPUNIT=~5.7
+        - PHPUNIT=~6
+      - 7.1
+      env:
+        - PHPUNIT=~5.7
+        - PHPUNIT=~6
+      - nightly
+      env:
+        - PHPUNIT=~5.7
+        - PHPUNIT=~6
+      - hhvm
+      env:
+        - PHPUNIT=~5.7
+        - PHPUNIT=~6

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,12 @@ script:
 matrix:
   include:
       - php: 5.6
-        env:
-          - PHPUNIT=~5.7
+        env: PHPUNIT=~5.7
       - php: 7.0
-        env:
-          - PHPUNIT=~5.7
-          - PHPUNIT=~6
+        env: PHPUNIT=~5.7
       - php: 7.1
-        env:
-          - PHPUNIT=~5.7
-          - PHPUNIT=~6
+        env: PHPUNIT=~6
       - php: nightly
-        env:
-          - PHPUNIT=~5.7
-          - PHPUNIT=~6
+        env: PHPUNIT=~6
       - php: hhvm
-        env:
-          - PHPUNIT=~5.7
-          - PHPUNIT=~6
+        env: PHPUNIT=~5.7

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "phpunit/phpunit": ">=4.7"
+        "phpunit/phpunit": ">=5.7 <7"
     },
     "autoload": {
         "psr-4": { "MyBuilder\\PhpunitAccelerator\\": "src" }

--- a/src/TestListener.php
+++ b/src/TestListener.php
@@ -2,7 +2,13 @@
 
 namespace MyBuilder\PhpunitAccelerator;
 
-class TestListener implements \PHPUnit_Framework_TestListener
+use PHPUnit\Framework\BaseTestListener;
+
+if (!interface_exists('\PHPUnit\Framework\Test')) {
+    class_alias('\PHPUnit_Framework_Test', '\PHPUnit\Framework\Test');
+}
+
+class TestListener extends BaseTestListener
 {
     private $ignorePolicy;
 
@@ -13,7 +19,7 @@ class TestListener implements \PHPUnit_Framework_TestListener
         $this->ignorePolicy = ($ignorePolicy) ?: new NeverIgnoreTestPolicy();
     }
 
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    public function endTest(\PHPUnit\Framework\Test $test, $time)
     {
         $testReflection = new \ReflectionObject($test);
 
@@ -24,7 +30,7 @@ class TestListener implements \PHPUnit_Framework_TestListener
         $this->safelyFreeProperties($test, $testReflection->getProperties());
     }
 
-    private function safelyFreeProperties(\PHPUnit_Framework_Test $test, array $properties)
+    private function safelyFreeProperties(\PHPUnit\Framework\Test $test, array $properties)
     {
         foreach ($properties as $property) {
             if ($this->isSafeToFreeProperty($property)) {
@@ -43,29 +49,11 @@ class TestListener implements \PHPUnit_Framework_TestListener
         return 0 !== strpos($property->getDeclaringClass()->getName(), self::PHPUNIT_PROPERTY_PREFIX);
     }
 
-    private function freeProperty(\PHPUnit_Framework_Test $test, \ReflectionProperty $property)
+    private function freeProperty(\PHPUnit\Framework\Test $test, \ReflectionProperty $property)
     {
         $property->setAccessible(true);
         $property->setValue($test, null);
     }
-
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {}
-
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
-
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time) {}
-
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
-
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
-
-    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite) {}
-
-    public function startTest(\PHPUnit_Framework_Test $test) {}
-
-    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
-    
-    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time) {}
 }
 
 class NeverIgnoreTestPolicy implements IgnoreTestPolicy

--- a/tests/TestListenerTest.php
+++ b/tests/TestListenerTest.php
@@ -3,7 +3,7 @@
 use MyBuilder\PhpunitAccelerator\TestListener;
 use MyBuilder\PhpunitAccelerator\IgnoreTestPolicy;
 
-class TestListenerTest extends \PHPUnit_Framework_TestCase
+class TestListenerTest extends \PHPUnit\Framework\TestCase
 {
     private $dummyTest;
 
@@ -63,7 +63,7 @@ class TestListenerTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class PHPUnit_Fake extends \PHPUnit_Framework_TestCase
+class PHPUnit_Fake extends \PHPUnit\Framework\TestCase
 {
     public $phpUnitProperty = 1;
 }


### PR DESCRIPTION
This is to replace #12.

Required phpunit version was bumped to >=5.7, because starting from that version almost complete forward compability was present (it's not full, I had to add `\PHPUnit\Framework\Test` shim and there is even more classes missing).

Travis config was updated to test phpunit ~5.7 and ~6.

New major version should be released after this, because v1 had >=4.7 compatibility.